### PR TITLE
Add dynamic column selection for cart payload based on existence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Use this data to send automated cart recovery reminders to increase your convers
 | Shopware Version | Plugin Version | Download |
 |------------------|----------------|----------|
 | 6.4              | 1.7.1          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/1.7.1) |
-| 6.5              | 3.0.2          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/3.0.2) |
-| 6.6              | 3.0.2          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/3.0.2) |
+| 6.5              | 3.0.3          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/3.0.3) |
+| 6.6              | 3.0.3          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/3.0.3) |
 
-> ✅ Note: Plugin version `3.0.2` supports both Shopware `6.5` and `6.6`.
+> ✅ Note: Plugin version `3.0.3` supports both Shopware `6.5` and `6.6`.
 
 ---
 
@@ -96,7 +96,7 @@ Make sure this timeout is **shorter** than Shopware's own cart expiration settin
 |----------------|-------------------------------|
 | 1.7.1          | 6.4                           |
 | 2.0.0          | 6.5                           |
-| 3.0.2          | 6.5, 6.6                      |
+| 3.0.3          | 6.5, 6.6                      |
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mailcampaigns/shopware-6-abandoned-cart-plugin",
     "description": "A Shopware 6 plugin for \"abandoned\" carts.",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
On a fresh installation of 6.5 or 6.6 the `payload` field exists.
For some reason on older installations the `payload` field is called `cart`.