### PR TITLE
Performance optimization

### DIFF
--- a/src/Core/Checkout/AbandonedCart/AbandonedCartFactory.php
+++ b/src/Core/Checkout/AbandonedCart/AbandonedCartFactory.php
@@ -7,6 +7,7 @@ namespace MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart;
 use MailCampaigns\AbandonedCart\Exception\InvalidCartDataException;
 use MailCampaigns\AbandonedCart\Exception\MissingCartDataException;
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 
 /**
  * @author Twan Haverkamp <twan@mailcampaigns.nl>
@@ -31,7 +32,11 @@ class AbandonedCartFactory
     {
         self::validateData($data);
 
-        $cart = unserialize($data['payload']);
+        try {
+            $cart = !empty($data['compressed']) ? CacheValueCompressor::uncompress($data['payload']) : unserialize((string) $data['payload']);
+        } catch (\Throwable $e) {
+            $cart = null;
+        }
 
         if (!$cart instanceof Cart) {
             throw new InvalidCartDataException('cart', Cart::class, $cart);

--- a/src/Core/Checkout/AbandonedCart/AbandonedCartManager.php
+++ b/src/Core/Checkout/AbandonedCart/AbandonedCartManager.php
@@ -63,6 +63,9 @@ final class AbandonedCartManager
 
             // Get the abandoned cart ID by token.
             $abandonedCartId = $this->findAbandonedCartIdByToken($abandonedCart->getCartToken());
+            if ($abandonedCartId === null) {
+                continue;
+            }
 
             $this->abandonedCartRepository->upsert([
                 [

--- a/src/Core/Checkout/Cart/CartRepository.php
+++ b/src/Core/Checkout/Cart/CartRepository.php
@@ -110,6 +110,7 @@ final class CartRepository
             }
 
             if (!$cart instanceof \Shopware\Core\Checkout\Cart\Cart) {
+                unset($data[$key]);
                 continue;
             }
 

--- a/src/Core/Checkout/Cart/CartRepository.php
+++ b/src/Core/Checkout/Cart/CartRepository.php
@@ -55,6 +55,8 @@ final class CartRepository
         if($this->versionHelper->getMajorMinorShopwareVersion() === '6.5') {
             $qb->select("c.token, c.$field AS payload, c.compressed, c.created_at, c.updated_at AS c_updated_at, ac.updated_at AS ac_updated_at")
                 ->addSelect('LOWER(HEX(c.customer_id)) AS customer_id')
+                ->addSelect('c.price')
+                ->addSelect('c.line_item_count')
                 ->from('cart', 'c')
                 ->leftJoin('c', 'abandoned_cart', 'ac', 'c.token = ac.cart_token')
                 ->join('c', 'customer', 'customer', 'customer.id = c.customer_id AND customer.active = 1')
@@ -77,6 +79,8 @@ final class CartRepository
         } else if($this->versionHelper->getMajorMinorShopwareVersion() === '6.6') {
             $qb->select("c.token, c.$field AS payload, c.compressed, c.created_at, ac.updated_at")
                 ->addSelect('LOWER(HEX(c.customer_id)) AS customer_id')
+                ->addSelect('c.price')
+                ->addSelect('c.line_item_count')
                 ->from('cart', 'c')
                 ->leftJoin('c', 'abandoned_cart', 'ac', 'c.token = ac.cart_token')
                 ->join('c', 'customer', 'customer', 'customer.id = c.customer_id AND customer.active = 1')
@@ -112,12 +116,6 @@ final class CartRepository
                 unset($data[$key]);
                 continue;
             }
-
-            // Add price to each result
-            $data[$key]['price'] = $cart->getPrice()->getTotalPrice();
-
-            // Add line item count to result
-            $data[$key]['line_item_count'] = count($cart->getLineItems());
 
             // Remove customers that have placed an order after the cart was created
             $qb = $this->connection->createQueryBuilder();

--- a/src/Core/Checkout/Cart/CartRepository.php
+++ b/src/Core/Checkout/Cart/CartRepository.php
@@ -175,9 +175,9 @@ final class CartRepository
             FROM abandoned_cart
 
             LEFT JOIN cart ON abandoned_cart.cart_token = cart.token
-                AND cart.`token` IN (:tokens)
 
-            WHERE cart.token IS NULL;
+            WHERE abandoned_cart.cart_token IN (:tokens)
+                AND cart.token IS NULL;
         SQL);
 
         $statement->bindValue('tokens', $abandonedCartTokens);

--- a/src/Core/Checkout/Cart/CartRepository.php
+++ b/src/Core/Checkout/Cart/CartRepository.php
@@ -103,14 +103,11 @@ final class CartRepository
                 continue;
             }
 
-            $firstAddress = $cart->getDeliveries()->getAddresses()->first();
-            if($firstAddress) {
-                $customerId = $firstAddress->getCustomerId();
-                if(!$customerId) {
-                    // Return only carts with a customer ID.
-                    unset($data[$key]);
-                    continue;
-                }
+            $customerId = $cart->getDeliveries()->getAddresses()->first()?->getCustomerId();
+            if(!$customerId) {
+                // Return only carts with a customer ID.
+                unset($data[$key]);
+                continue;
             }
 
             // Remove carts that are marked as recalculated since they can be considered as garbage

--- a/src/Core/Checkout/Cart/CartRepository.php
+++ b/src/Core/Checkout/Cart/CartRepository.php
@@ -152,6 +152,12 @@ final class CartRepository
                 ->andWhere($qb->expr()->gte('oc.created_at', ':cartCreatedAt'))
                 ->setParameter('customerId', $data[$key]['customer_id'])
                 ->setParameter('cartCreatedAt', $data[$key]['created_at']);
+
+            $result = $qb->executeQuery()->fetchOne();
+            if($result !== false) {
+                unset($data[$key]);
+                continue;
+            }
         }
 
         return $data;

--- a/src/Core/Checkout/Cart/CartRepository.php
+++ b/src/Core/Checkout/Cart/CartRepository.php
@@ -53,8 +53,9 @@ final class CartRepository
 
         $field = $this->payloadExists() ? 'payload' : 'cart';
         if($this->versionHelper->getMajorMinorShopwareVersion() === '6.5') {
-            $qb->select("c.token, c.$field AS payload, c.compressed, c.created_at, c.updated_at AS c_updated_at, ac.updated_at AS ac_updated_at")
+            $qb->select("c.token, c.$field AS payload, c.created_at, c.updated_at AS c_updated_at, ac.updated_at AS ac_updated_at")
                 ->addSelect('LOWER(HEX(c.customer_id)) AS customer_id')
+                ->addSelect('c.compressed')
                 ->addSelect('c.price')
                 ->addSelect('c.line_item_count')
                 ->from('cart', 'c')
@@ -77,8 +78,9 @@ final class CartRepository
                 );
             }
         } else if($this->versionHelper->getMajorMinorShopwareVersion() === '6.6') {
-            $qb->select("c.token, c.$field AS payload, c.compressed, c.created_at, ac.updated_at")
+            $qb->select("c.token, c.$field AS payload, c.created_at, ac.updated_at")
                 ->addSelect('LOWER(HEX(c.customer_id)) AS customer_id')
+                ->addSelect('c.compressed')
                 ->addSelect('c.price')
                 ->addSelect('c.line_item_count')
                 ->from('cart', 'c')


### PR DESCRIPTION
I have launched the plugin on our store with around 250k active carts. In the current state, it is inoperable. So this pull request brings two new features:

1. I have moved the tokens obtaining procedure into a separate query. In this particular case, even with 20k carts that were considered abandoned, our server has managed to process the fetch in around 200ms.
2. I have added support for compressed carts, as otherwise it would fail to unserialize them and throw an exception further down the stream.
3. I have noticed that the check for orders that were placed after a cart was created was never implemented. Fixed it.

So far, this is it.

Best regards,
Ruslan