### PR TITLE
Add Symfony events for abandoned carts

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,27 @@ DELETE /api/abandoned-cart/{id}
 - **PATCH**: Update specific fields of an abandoned cart.
 - **DELETE**: Remove an abandoned cart.
 
+## 📡 Events
+
+The plugin dispatches several events that you can listen to in your custom code:
+
+### AfterCartMarkedAsAbandonedEvent
+Dispatched when a cart is marked as abandoned. Contains:
+- `AbandonedCartEntity`: Newly created abandoned cart entity
+- `array`: Original Shopware cart data
+- `Context`: Shopware context
+
+### AfterAbandonedCartUpdatedEvent
+Dispatched when an abandoned cart is updated. Contains:
+- `AbandonedCartEntity`: Updated abandoned cart entity
+- `array`: Updated Shopware cart data
+- `Context`: Shopware context
+
+### AfterAbandonedCartDeletedEvent
+Dispatched when an abandoned cart is deleted. Contains:
+- `string`: ID of the deleted abandoned cart
+- `string`: Token of the deleted cart
+- `Context`: Shopware context
 
 ## 📦 Release Overview
 

--- a/src/Core/Checkout/AbandonedCart/Event/AfterAbandonedCartDeletedEvent.php
+++ b/src/Core/Checkout/AbandonedCart/Event/AfterAbandonedCartDeletedEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\Event;
+
+use Shopware\Core\Framework\Context;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class AfterAbandonedCartDeletedEvent extends Event
+{
+    public function __construct(
+        protected string $abandonedCartId,
+        protected string $token,
+        protected Context $context
+    )
+    {
+    }
+
+    public function getAbandonedCartId(): string
+    {
+        return $this->abandonedCartId;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Checkout/AbandonedCart/Event/AfterAbandonedCartUpdatedEvent.php
+++ b/src/Core/Checkout/AbandonedCart/Event/AfterAbandonedCartUpdatedEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\Event;
+
+use MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartEntity;
+use Shopware\Core\Framework\Context;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class AfterAbandonedCartUpdatedEvent extends Event
+{
+    public function __construct(
+        protected AbandonedCartEntity $abandonedCart,
+        protected array $cartData,
+        protected Context $context
+    )
+    {
+    }
+
+    public function getAbandonedCart(): AbandonedCartEntity
+    {
+        return $this->abandonedCart;
+    }
+
+    public function getCartData(): array
+    {
+        return $this->cartData;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Checkout/AbandonedCart/Event/AfterCartMarkedAsAbandonedEvent.php
+++ b/src/Core/Checkout/AbandonedCart/Event/AfterCartMarkedAsAbandonedEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\Event;
+
+use MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartEntity;
+use Shopware\Core\Framework\Context;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class AfterCartMarkedAsAbandonedEvent extends Event
+{
+    public function __construct(
+        protected AbandonedCartEntity $abandonedCart,
+        protected array $cartData,
+        protected Context $context
+    )
+    {
+    }
+
+    public function getAbandonedCart(): AbandonedCartEntity
+    {
+        return $this->abandonedCart;
+    }
+
+    public function getCartData(): array
+    {
+        return $this->cartData;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -17,6 +17,7 @@
         <service id="MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartManager">
             <argument type="service" id="MailCampaigns\AbandonedCart\Core\Checkout\Cart\CartRepository" />
             <argument type="service" id="abandoned_cart.repository" />
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="MailCampaigns\AbandonedCart\Command\DeleteAbandonedCartCommand">


### PR DESCRIPTION
This allows other plugins to hook into the abandoned cart process and perform actions, such as sending notifications.