### PR TITLE
Bump version to 3.0.9 and add support for Shopware 6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use this data to send automated cart recovery reminders to increase your convers
 - 👤 Only returns known, non-order customers
 - ⏱️ Configurable timeout in seconds (default: 3600)
 - 🛠️ Compatible with scheduled tasks & message queue
-- ✅ Supports Shopware 6.4 → 6.6
+- ✅ Supports Shopware 6.4 → 6.7
 
 ---
 
@@ -30,10 +30,7 @@ Use this data to send automated cart recovery reminders to increase your convers
 | Shopware Version | Plugin Version | Download |
 |------------------|----------------|----------|
 | 6.4              | 1.7.1          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/1.7.1) |
-| 6.5              | 3.0.8          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/3.0.8) |
-| 6.6              | 3.0.8          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/3.0.8) |
-
-> ✅ Note: Plugin version `3.0.8` supports both Shopware `6.5` and `6.6`.
+| 6.5, 6.6, 6.7    | 3.0.9          | [🔗 View Release](https://github.com/mailcampaigns/shopware-6-abandoned-cart-plugin/releases/tag/3.0.9) |
 
 ---
 
@@ -148,14 +145,6 @@ Dispatched when an abandoned cart is updated. Contains:
 - `AbandonedCartEntity`: Updated abandoned cart entity
 - `array`: Updated Shopware cart data
 - `Context`: Shopware context
-
-## 📦 Release Overview
-
-| Plugin Version | Compatible Shopware Versions |
-|----------------|-------------------------------|
-| 1.7.1          | 6.4                           |
-| 2.0.0          | 6.5                           |
-| 3.0.8          | 6.5, 6.6                      |
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mailcampaigns/shopware-6-abandoned-cart-plugin",
     "description": "A Shopware 6 plugin for \"abandoned\" carts.",
-    "version": "3.0.8",
+    "version": "3.0.9",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [
@@ -12,7 +12,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-json": "*",
-        "shopware/core": "6.5.* || 6.6.*"
+        "shopware/core": "6.5.* || 6.6.* || 6.7.*"
     },
     "extra": {
         "shopware-plugin-class": "MailCampaigns\\AbandonedCart\\MailCampaignsAbandonedCart",

--- a/src/Core/Checkout/Cart/Handler/CartRepositoryHandlerFactory.php
+++ b/src/Core/Checkout/Cart/Handler/CartRepositoryHandlerFactory.php
@@ -26,7 +26,7 @@ class CartRepositoryHandlerFactory
 
         return match ($version) {
             '6.5' => new Shopware65CartRepositoryHandler($this->connection, $this->logger),
-            '6.6' => new Shopware66CartRepositoryHandler($this->connection, $this->logger),
+            '6.6', '6.7' => new Shopware66CartRepositoryHandler($this->connection, $this->logger), // 6.7 uses same handler as 6.6
             default => throw new \RuntimeException('Unsupported Shopware version ' . $version),
         };
     }

--- a/src/Core/Checkout/Cart/Handler/Shopware66CartRepositoryHandler.php
+++ b/src/Core/Checkout/Cart/Handler/Shopware66CartRepositoryHandler.php
@@ -88,7 +88,7 @@ class Shopware66CartRepositoryHandler implements CartRepositoryHandlerInterface
 
     public function getSupportedVersion(): string
     {
-        return '6.6';
+        return '6.6-6.7'; // Updated to support both 6.6 and 6.7
     }
 
     /**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -51,6 +51,8 @@
         <service id="MailCampaigns\AbandonedCart\Service\ScheduledTask\RelaunchAbandonedCartSchedulerTaskHandler">
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartManager" />
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="MailCampaigns\AbandonedCart\Service\ShopwareVersionHelper" on-invalid="null" />
             <tag name="messenger.message_handler" />
         </service>
 
@@ -61,6 +63,8 @@
         <service id="MailCampaigns\AbandonedCart\Service\ScheduledTask\UpdateAbandonedCartTaskHandler">
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartManager" />
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="MailCampaigns\AbandonedCart\Service\ShopwareVersionHelper" on-invalid="null" />
             <tag name="messenger.message_handler" />
         </service>
 
@@ -71,6 +75,8 @@
         <service id="MailCampaigns\AbandonedCart\Service\ScheduledTask\MarkAbandonedCartTaskHandler">
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartManager" />
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="MailCampaigns\AbandonedCart\Service\ShopwareVersionHelper" on-invalid="null" />
             <tag name="messenger.message_handler" />
         </service>
 

--- a/src/Service/ScheduledTask/AbstractVersionCompatibleScheduledTaskHandler.php
+++ b/src/Service/ScheduledTask/AbstractVersionCompatibleScheduledTaskHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MailCampaigns\AbandonedCart\Service\ScheduledTask;
+
+use MailCampaigns\AbandonedCart\Service\ShopwareVersionHelper;
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+
+/**
+ * Abstract base class that provides version compatibility for ScheduledTaskHandler
+ * between Shopware 6.6 and 6.7
+ */
+abstract class AbstractVersionCompatibleScheduledTaskHandler extends ScheduledTaskHandler
+{
+    public function __construct(
+        EntityRepository $scheduledTaskRepository,
+        ?LoggerInterface $exceptionLogger = null,
+        ?ShopwareVersionHelper $versionHelper = null
+    ) {
+        // For backward compatibility, create version helper if not provided
+        if ($versionHelper === null) {
+            $versionHelper = new ShopwareVersionHelper();
+        }
+        
+        $version = $versionHelper->getMajorMinorShopwareVersion();
+        
+        if (version_compare($version, '6.7', '>=')) {
+            // Shopware 6.7+ - requires logger
+            if ($exceptionLogger === null) {
+                throw new \InvalidArgumentException('LoggerInterface is required for Shopware 6.7+');
+            }
+            parent::__construct($scheduledTaskRepository, $exceptionLogger);
+        } else {
+            // Shopware 6.6 - only requires repository
+            parent::__construct($scheduledTaskRepository);
+        }
+    }
+}

--- a/src/Service/ScheduledTask/MarkAbandonedCartTaskHandler.php
+++ b/src/Service/ScheduledTask/MarkAbandonedCartTaskHandler.php
@@ -6,7 +6,8 @@ namespace MailCampaigns\AbandonedCart\Service\ScheduledTask;
 
 use Doctrine\DBAL\Exception;
 use MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartManager;
-use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use MailCampaigns\AbandonedCart\Service\ShopwareVersionHelper;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -14,13 +15,15 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  * @author Twan Haverkamp <twan@mailcampaigns.nl>
  */
 #[AsMessageHandler(handles: MarkAbandonedCartTask::class)]
-final class MarkAbandonedCartTaskHandler extends ScheduledTaskHandler
+final class MarkAbandonedCartTaskHandler extends AbstractVersionCompatibleScheduledTaskHandler
 {
     public function __construct(
         EntityRepository $scheduledTaskRepository,
-        private readonly AbandonedCartManager $manager
+        private readonly AbandonedCartManager $manager,
+        ?LoggerInterface $exceptionLogger = null,
+        ?ShopwareVersionHelper $versionHelper = null
     ) {
-        parent::__construct($scheduledTaskRepository);
+        parent::__construct($scheduledTaskRepository, $exceptionLogger, $versionHelper);
     }
 
     /**

--- a/src/Service/ScheduledTask/RelaunchAbandonedCartSchedulerTaskHandler.php
+++ b/src/Service/ScheduledTask/RelaunchAbandonedCartSchedulerTaskHandler.php
@@ -6,7 +6,8 @@ namespace MailCampaigns\AbandonedCart\Service\ScheduledTask;
 
 use Doctrine\DBAL\Exception;
 use MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartManager;
-use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use MailCampaigns\AbandonedCart\Service\ShopwareVersionHelper;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -14,13 +15,15 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  * @author Ruslan Belziuk <ruslan@dumka.pro>
  */
 #[AsMessageHandler(handles: RelaunchAbandonedCartSchedulerTask::class)]
-final class RelaunchAbandonedCartSchedulerTaskHandler extends ScheduledTaskHandler
+final class RelaunchAbandonedCartSchedulerTaskHandler extends AbstractVersionCompatibleScheduledTaskHandler
 {
     public function __construct(
         EntityRepository $scheduledTaskRepository,
-        private readonly AbandonedCartManager $manager
+        private readonly AbandonedCartManager $manager,
+        ?LoggerInterface $exceptionLogger = null,
+        ?ShopwareVersionHelper $versionHelper = null
     ) {
-        parent::__construct($scheduledTaskRepository);
+        parent::__construct($scheduledTaskRepository, $exceptionLogger, $versionHelper);
     }
 
     /**

--- a/src/Service/ScheduledTask/UpdateAbandonedCartTaskHandler.php
+++ b/src/Service/ScheduledTask/UpdateAbandonedCartTaskHandler.php
@@ -6,7 +6,8 @@ namespace MailCampaigns\AbandonedCart\Service\ScheduledTask;
 
 use Doctrine\DBAL\Exception;
 use MailCampaigns\AbandonedCart\Core\Checkout\AbandonedCart\AbandonedCartManager;
-use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use MailCampaigns\AbandonedCart\Service\ShopwareVersionHelper;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -14,13 +15,15 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  * @author Max Seelig <max.seelig@heroesonly.com>
  */
 #[AsMessageHandler(handles: UpdateAbandonedCartTask::class)]
-final class UpdateAbandonedCartTaskHandler extends ScheduledTaskHandler
+final class UpdateAbandonedCartTaskHandler extends AbstractVersionCompatibleScheduledTaskHandler
 {
     public function __construct(
         EntityRepository $scheduledTaskRepository,
-        private readonly AbandonedCartManager $manager
+        private readonly AbandonedCartManager $manager,
+        ?LoggerInterface $exceptionLogger = null,
+        ?ShopwareVersionHelper $versionHelper = null
     ) {
-        parent::__construct($scheduledTaskRepository);
+        parent::__construct($scheduledTaskRepository, $exceptionLogger, $versionHelper);
     }
 
     /**


### PR DESCRIPTION
Update the plugin version to 3.0.9 and extend compatibility to include Shopware 6.7. Enhance cart repository handling and scheduled task handlers to support both Shopware 6.6 and 6.7.